### PR TITLE
Add cookie secret getter/setter to IUserState interface

### DIFF
--- a/pinterface.go
+++ b/pinterface.go
@@ -79,6 +79,8 @@ type IUserState interface {
 	Username(req *http.Request) string
 	CookieTimeout(username string) int64
 	SetCookieTimeout(cookieTime int64)
+	CookieSecret(username string) string
+	SetCookieSecret(cookieSecret string)
 	PasswordAlgo() string
 	SetPasswordAlgo(algorithm string) error
 	HashPassword(username, password string) string


### PR DESCRIPTION
Looks like the CookieSecret getter and setter is missing from the interface, based on https://github.com/xyproto/permissionbolt/commit/e60b21f434c6bd58a05a271f4c7e0ba559bebdbe

